### PR TITLE
feat: add suppor for fan and multilight devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
 # hass-enki-component
+
 Enki custom component for Home Assistant
 
-only tested with Eglo V-link tunable white
+Tested devices:
+- Eglo V-link tunable white
+- Inspire Radix ceiling fan with light
 
 Howto :
+
 - install HACS
 - add this repo
 - add Enki integration
+
+## Live API test
+
+This repository includes a standalone live diagnostics script that can authenticate against Enki
+and print available devices/actions from your account. This can help to develop and debug the
+component against the real API.
+
+Before running it locally, install runtime dependencies:
+
+```bash
+python -m pip install aiohttp
+```
+
+Run the script with credentials as parameters:
+
+```bash
+python tools/enki_api_live.py --user "your-email@example.com" --password "your-password"
+```
+
+You can also use environment variables:
+
+```bash
+export ENKI_USER="your-email@example.com"
+export ENKI_PASSWORD="your-password"
+python tools/enki_api_live.py
+```

--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -14,9 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .coordinator import EnkiCoordinator
 
 #PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
-PLATFORMS: list[Platform] = [Platform.LIGHT]
-
-type EnkiConfigEntry = ConfigEntry[RuntimeData]
+PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.FAN]
 
 
 @dataclass
@@ -24,6 +22,9 @@ class RuntimeData:
     """Class to hold your data."""
 
     coordinator: DataUpdateCoordinator
+
+
+EnkiConfigEntry = ConfigEntry[RuntimeData]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: EnkiConfigEntry) -> bool:

--- a/custom_components/enki/api.py
+++ b/custom_components/enki/api.py
@@ -1,7 +1,12 @@
 """Enki API."""
 
+from __future__ import annotations
+
 import aiohttp
+import asyncio
+import logging
 from dataclasses import dataclass
+from collections.abc import Awaitable, Callable
 from typing import Any
 import time
 
@@ -13,7 +18,9 @@ from .const import (
     ENKI_BFF_API_KEY,
     ENKI_NODE_API_KEY,
     ENKI_REFERENTIEL_API_KEY,
-    ENKI_LIGHTS_API_KEY)
+    ENKI_LIGHTS_API_KEY,
+    ENKI_AIRFLOW_API_KEY,
+    ENKI_POWER_API_KEY)
 
 proxy = None
 
@@ -32,6 +39,12 @@ class API:
         """Initialise."""
         self.user = user
         self.pwd = pwd
+        self._type_refreshers: dict[str, Callable[[dict[str, Any]], Awaitable[None]]] = {
+            "lights": self._refresh_lights_device,
+        }
+        self._device_type_refreshers: dict[str, Callable[[dict[str, Any]], Awaitable[None]]] = {
+            "ceiling_fans": self._refresh_ceiling_fan_device,
+        }
 
     @property
     def controller_name(self) -> str:
@@ -67,10 +80,15 @@ class API:
                         self._tokenExpiresTime = tokenExpiresTime
                         return True
                     else:
+                        response = await resp.text()
                         LOGGER.error("Error connecting to api. status %s, response %s", resp.status, str(response))
                         raise APIAuthError("Error connecting to api. Invalid username or password.")
-        except Exception as e:
-            raise APIConnectionError("Error connecting to api : " + repr(e))
+        except APIAuthError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+            raise APIConnectionError("Error connecting to api : " + repr(err)) from err
+        except Exception as err:
+            raise APIConnectionError("Unexpected error connecting to api : " + repr(err)) from err
 
 # *******************************************************
     async def get_homes(self):
@@ -91,11 +109,14 @@ class API:
                         homes.append(home["id"])
                     return homes
                 else:
+                    response = await resp.text()
                     LOGGER.error("Error on get_homes. status %s, response %s", resp.status, str(response))
                     raise ValueError("bad credentials")
 
-    def merge_properties(self, device, properties):
-         for prop in properties:
+    def merge_properties(self, device: dict[str, Any], properties: dict[str, Any] | None) -> None:
+        if not properties:
+            return
+        for prop in properties:
             if prop != "id":
                 device[prop] = properties[prop]
 
@@ -120,6 +141,14 @@ class API:
                                 "homeId": home_id,
                                 "deviceId": item["metadata"]["deviceId"],
                                 "nodeId": item["metadata"]["nodeId"],
+                                "deviceType": item["metadata"].get("deviceType"),
+                                "mainChangeCapabilityId": item["metadata"].get("mainChangeCapabilityId"),
+                                "mainCheckCapabilityId": item["metadata"].get("mainCheckCapabilityId"),
+                                "mainChangeCapabilityEndpoints": [
+                                    endpoint.get("id")
+                                    for endpoint in item["metadata"].get("mainChangeCapability", {}).get("endpoints", [])
+                                    if endpoint.get("id") is not None
+                                ],
                                 "deviceName": item["title"]["label"],
                                 "state": item["state"],
                                 "isEnabled": item["isEnabled"]
@@ -128,9 +157,6 @@ class API:
 
                             node_info = await self.get_node(home_id, device.get("nodeId"))
                             self.merge_properties(device, node_info)
-                            
-                            device_info = await self.get_device(device.get("deviceId"))
-                            self.merge_properties(device, device_info)
 
                             await self.refresh_device(device)
 
@@ -138,6 +164,7 @@ class API:
                     return devices
                   
                 else:
+                    response = await resp.text()
                     LOGGER.error("Error on get_items_in_section_for_home. status %s, response %s", resp.status, str(response))
                     raise ValueError("bad credentials")
 
@@ -145,11 +172,42 @@ class API:
         """Update device details"""
         device_info = await self.get_device(device.get("deviceId"))
         self.merge_properties(device, device_info)
-        if device["type"] == "lights" and device["isEnabled"]:
-            # get lights details (on/off, brightness, temperature, etc)
-            light_details = await self.get_light_details(device.get("homeId"), device.get("nodeId"))
-            self.merge_properties(device, light_details)
+        if not device.get("isEnabled"):
+            return device
+
+        type_refresher = self._type_refreshers.get(device.get("type"))
+        if type_refresher is not None:
+            await type_refresher(device)
+
+        device_type_refresher = self._device_type_refreshers.get(device.get("deviceType"))
+        if device_type_refresher is not None:
+            await device_type_refresher(device)
+
         return device
+
+    async def _refresh_lights_device(self, device: dict[str, Any]) -> None:
+        """Refresh state for standard light devices."""
+        light_details = await self.get_light_details(device.get("homeId"), device.get("nodeId"))
+        self.merge_properties(device, light_details)
+
+    async def _refresh_ceiling_fan_device(self, device: dict[str, Any]) -> None:
+        """Refresh light, power and airflow state for ceiling fan devices."""
+        await self._refresh_lights_device(device)
+
+        power_details = await self.get_electrical_power_details(device.get("homeId"), device.get("nodeId"))
+        self.merge_properties(device, {
+            "electricalPower": power_details.get("lastReportedValue"),
+            "electricalEndpoints": power_details.get("endpoints", []),
+        })
+
+        fan_speed = await self.get_fan_speed(device.get("homeId"), device.get("nodeId"))
+        fan_rotation = await self.get_fan_rotation_direction(device.get("homeId"), device.get("nodeId"))
+        airflow_mode = await self.get_airflow_mode(device.get("homeId"), device.get("nodeId"))
+        self.merge_properties(device, {
+            "fanSpeed": fan_speed,
+            "fanRotationDirection": fan_rotation,
+            "airflowMode": airflow_mode,
+        })
 
     async def get_node(self, home_id, node_id):
         """Get details on a node."""
@@ -169,6 +227,10 @@ class API:
                     return response
 
                 else:
+                    response = await resp.text()
+                    if resp.status == 404:
+                        LOGGER.warning("Node not found on get_node. status %s, response %s", resp.status, str(response))
+                        return {}
                     LOGGER.error("Error on get_node. status %s, response %s", resp.status, str(response))
                     raise ValueError("bad credentials")
 
@@ -177,7 +239,7 @@ class API:
         await self.check_connected()
         async with aiohttp.ClientSession() as session, session.request(
             method="GET",
-            url=f"{ENKI_URL}/api-enki-referentiel-agg-prod/v1/devices/{id}?version=2.15.0",
+            url=f"{ENKI_URL}/api-enki-referentiel-agg-prod/v1/devices/{id}",
             headers={"Authorization": f"{self._token_type} {self._access_token}",
                     "X-Gateway-APIKey": ENKI_REFERENTIEL_API_KEY},
             proxy=proxy,) as resp:
@@ -188,6 +250,10 @@ class API:
                     return response
 
                 else:
+                    response = await resp.text()
+                    if resp.status == 404:
+                        LOGGER.debug("Device not found on get_device. status %s, response %s", resp.status, str(response))
+                        return {}
                     LOGGER.error("Error on get_device. status %s, response %s", resp.status, str(response))
                     raise ValueError("bad credentials")
 
@@ -208,6 +274,10 @@ class API:
                     return response
 
                 else:
+                    response = await resp.text()
+                    if resp.status == 404:
+                        LOGGER.warning("Light details not found on get_light_details. status %s, response %s", resp.status, str(response))
+                        return {}
                     LOGGER.error("Error on get_light_details. status %s, response %s", resp.status, str(response))
                     raise ValueError("bad credentials")
 
@@ -227,10 +297,153 @@ class API:
             json=data) as resp:
 
                 if resp.status != 202:
-                    response = await resp.json()
+                    response = await resp.text()
                     LOGGER.debug(resp.status)
                     LOGGER.error("Error on change_light_state. status %s, response %s", resp.status, str(response))
                     raise ValueError("bad credentials")
+
+    async def _check_airflow_value(self, home_id, node_id, endpoint):
+        """Read airflow value from one check endpoint."""
+        await self.check_connected()
+        async with aiohttp.ClientSession() as session, session.request(
+            method="GET",
+            url=f"{ENKI_URL}/api-enki-airflow-prod/v1/airflow/{node_id}/{endpoint}",
+            headers={
+                "Authorization": f"{self._token_type} {self._access_token}",
+                "homeId": home_id,
+                "X-Gateway-APIKey": ENKI_AIRFLOW_API_KEY,
+            },
+            proxy=proxy,
+        ) as resp:
+            if resp.status == 200:
+                response = await resp.json()
+                return response.get("lastReportedValue")
+
+            response = await resp.text()
+            if resp.status == 404:
+                LOGGER.warning("Airflow endpoint not found on %s. status %s, response %s", endpoint, resp.status, str(response))
+                return None
+            LOGGER.error("Error on airflow check %s. status %s, response %s", endpoint, resp.status, str(response))
+            raise ValueError("bad credentials")
+
+    async def get_electrical_power_details(self, home_id, node_id):
+        """Get electrical power state and endpoint states."""
+        await self.check_connected()
+        async with aiohttp.ClientSession() as session, session.request(
+            method="GET",
+            url=f"{ENKI_URL}/api-enki-power-prod/v1/power/{node_id}/check-electrical-power",
+            headers={
+                "Authorization": f"{self._token_type} {self._access_token}",
+                "homeId": home_id,
+                "X-Gateway-APIKey": ENKI_POWER_API_KEY,
+            },
+            proxy=proxy,
+        ) as resp:
+            if resp.status == 200:
+                return await resp.json()
+
+            response = await resp.text()
+            if resp.status == 404:
+                LOGGER.warning("Power endpoint not found. status %s, response %s", resp.status, str(response))
+                return {}
+            LOGGER.error("Error on power check. status %s, response %s", resp.status, str(response))
+            raise ValueError("bad credentials")
+
+    async def switch_electrical_power(self, home_id, node_id, value, endpoint_ids=None):
+        """Switch electrical power globally or for specific endpoints."""
+        await self.check_connected()
+        payload = {"value": value}
+        if endpoint_ids:
+            payload["endpoints"] = [{"id": endpoint_id} for endpoint_id in endpoint_ids]
+
+        before_state = None
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            try:
+                before_state = await self.get_electrical_power_details(home_id, node_id)
+            except Exception as err:
+                before_state = {"error": repr(err)}
+
+        LOGGER.info(
+            "Calling switch-electrical-power for node %s (home %s) payload=%s",
+            node_id,
+            home_id,
+            payload,
+        )
+
+        async with aiohttp.ClientSession() as session, session.request(
+            method="POST",
+            url=f"{ENKI_URL}/api-enki-power-prod/v1/power/{node_id}/switch-electrical-power",
+            headers={
+                "Authorization": f"{self._token_type} {self._access_token}",
+                "homeId": home_id,
+                "X-Gateway-APIKey": ENKI_POWER_API_KEY,
+            },
+            proxy=proxy,
+            json=payload,
+        ) as resp:
+            if resp.status == 202:
+                if LOGGER.isEnabledFor(logging.DEBUG):
+                    try:
+                        after_state = await self.get_electrical_power_details(home_id, node_id)
+                    except Exception as err:
+                        after_state = {"error": repr(err)}
+                    LOGGER.debug(
+                        "switch-electrical-power success node %s payload=%s before=%s after=%s",
+                        node_id,
+                        payload,
+                        before_state,
+                        after_state,
+                    )
+                return
+
+            response = await resp.text()
+            LOGGER.error("Error on power switch. status %s, response %s", resp.status, str(response))
+            raise ValueError("bad credentials")
+
+    async def _change_airflow_value(self, home_id, node_id, endpoint, value):
+        """Write airflow value to one change endpoint."""
+        await self.check_connected()
+        async with aiohttp.ClientSession() as session, session.request(
+            method="POST",
+            url=f"{ENKI_URL}/api-enki-airflow-prod/v1/airflow/{node_id}/{endpoint}",
+            headers={
+                "Authorization": f"{self._token_type} {self._access_token}",
+                "homeId": home_id,
+                "X-Gateway-APIKey": ENKI_AIRFLOW_API_KEY,
+            },
+            proxy=proxy,
+            json={"value": value},
+        ) as resp:
+            if resp.status == 202:
+                return
+
+            response = await resp.text()
+            LOGGER.error("Error on airflow change %s. status %s, response %s", endpoint, resp.status, str(response))
+            raise ValueError("bad credentials")
+
+    async def get_fan_speed(self, home_id, node_id):
+        """Get fan speed value."""
+        return await self._check_airflow_value(home_id, node_id, "check-fan-speed")
+
+    async def change_fan_speed(self, home_id, node_id, value):
+        """Set fan speed value."""
+        await self._change_airflow_value(home_id, node_id, "change-fan-speed", value)
+
+    async def get_fan_rotation_direction(self, home_id, node_id):
+        """Get fan rotation direction."""
+        return await self._check_airflow_value(home_id, node_id, "check-fan-rotation-direction")
+
+    async def change_fan_rotation_direction(self, home_id, node_id, value):
+        """Set fan rotation direction."""
+        await self._change_airflow_value(home_id, node_id, "change-fan-rotation-direction", value)
+
+    async def get_airflow_mode(self, home_id, node_id):
+        """Get airflow mode."""
+        return await self._check_airflow_value(home_id, node_id, "check-airflow-mode")
+
+    async def change_airflow_mode(self, home_id, node_id, value):
+        """Set airflow mode."""
+        await self._change_airflow_value(home_id, node_id, "change-airflow-mode", value)
 
 # *******************************************************
 

--- a/custom_components/enki/config_flow.py
+++ b/custom_components/enki/config_flow.py
@@ -7,18 +7,17 @@ import voluptuous as vol
 
 from homeassistant.config_entries import (
     ConfigFlow,
-    ConfigFlowResult,
 )
 
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
+    CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from .api import API, APIAuthError, APIConnectionError
-from .const import DOMAIN, LOGGER
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -32,12 +31,16 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
+    from .api import API, APIAuthError, APIConnectionError
+
     api = API(data[CONF_USERNAME], data[CONF_PASSWORD])
     try:
         await api.connect()
     except APIAuthError as err:
+        LOGGER.warning("Enki authentication failed for user %s: %s", data[CONF_USERNAME], err)
         raise InvalidAuth from err
     except APIConnectionError as err:
+        LOGGER.warning("Enki connection failed for user %s: %s", data[CONF_USERNAME], err)
         raise CannotConnect from err
     return {"title": f"Enki - {data[CONF_USERNAME]}"}
 
@@ -50,7 +53,7 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    ) -> dict[str, Any]:
         """Handle the initial step."""
         # Called when you initiate adding an integration via the UI
         errors: dict[str, str] = {}
@@ -62,28 +65,51 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
                 # The errors["base"] values match the values in your strings.json and translation files.
                 info = await validate_input(self.hass, user_input)
             except CannotConnect:
+                LOGGER.error("Enki config flow cannot connect for user %s", user_input.get(CONF_USERNAME))
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
+                LOGGER.error("Enki config flow invalid auth for user %s", user_input.get(CONF_USERNAME))
                 errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
             if "base" not in errors:
-                # Validation was successful, so create a unique id for this instance of your integration
-                # and create the config entry.
                 await self.async_set_unique_id(info.get("title"))
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=info["title"], data=user_input)
+                self._input_data = {**user_input, "_title": info["title"]}
+                return await self.async_step_polling()
 
         # Show initial form.
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
+    async def async_step_polling(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Handle the polling interval step."""
+        if user_input is not None:
+            title = self._input_data.pop("_title")
+            return self.async_create_entry(
+                title=title,
+                data={**self._input_data, CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL]},
+            )
+
+        return self.async_show_form(
+            step_id="polling",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+                        vol.Coerce(int), vol.Range(min=10, max=3600)
+                    ),
+                }
+            ),
+        )
+
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    ) -> dict[str, Any]:
         """Add reconfigure step to allow to reconfigure a config entry."""
         # This methid displays a reconfigure option in the integration and is
         # different to options.
@@ -98,8 +124,10 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 await validate_input(self.hass, user_input)
             except CannotConnect:
+                LOGGER.error("Enki reconfigure cannot connect for user %s", user_input.get(CONF_USERNAME))
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
+                LOGGER.error("Enki reconfigure invalid auth for user %s", user_input.get(CONF_USERNAME))
                 errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception")
@@ -119,6 +147,10 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_USERNAME, default=config_entry.data[CONF_USERNAME]
                     ): str,
                     vol.Required(CONF_PASSWORD): str,
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
                 }
             ),
             errors=errors,

--- a/custom_components/enki/const.py
+++ b/custom_components/enki/const.py
@@ -8,7 +8,7 @@ LOGGER: Logger = getLogger(__package__)
 DOMAIN = "enki"
 NAME = "Enki"
 
-DEFAULT_SCAN_INTERVAL = 5
+DEFAULT_SCAN_INTERVAL = 60
 
 ENKI_OIDC_URL = "https://keycloak-prod.iot.leroymerlin.fr/realms/enki/protocol/openid-connect/token"
 ENKI_URL = "https://enki.api.devportal.adeo.cloud"
@@ -17,3 +17,5 @@ ENKI_BFF_API_KEY = "Bco7qBHRHOQiSVcEHdgS0rijpebMBwkB"
 ENKI_NODE_API_KEY = "UBb0Kv6xXpG6bOvD8VZ9A63uxqQ4G1A3"
 ENKI_REFERENTIEL_API_KEY = "3uk9rlaIUgBsz1tEPV7GQMhhGfRwPFJY"
 ENKI_LIGHTS_API_KEY = "3OVsNulRsUXfr7Hze54OHx8l6qDu2UcE"
+ENKI_AIRFLOW_API_KEY = "hder4GeBrdbzQlV2R22dm2a9pbfTTHPj"
+ENKI_POWER_API_KEY = "DZ9MSuTT7sQxJWxxkBokAGvIt57qVl9N"

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -5,6 +5,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
 from homeassistant.core import DOMAIN, HomeAssistant
@@ -25,8 +26,8 @@ class EnkiCoordinator(DataUpdateCoordinator):
         self.user = config_entry.data[CONF_USERNAME]
         self.pwd = config_entry.data[CONF_PASSWORD]
 
-        # set variables from options.  You need a default here incase options have not been set
-        self.poll_interval = DEFAULT_SCAN_INTERVAL
+        # read polling interval from config entry data, falling back to default
+        self.poll_interval = config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
         # Initialise DataUpdateCoordinator
         super().__init__(
@@ -102,4 +103,17 @@ class EnkiCoordinator(DataUpdateCoordinator):
             device[key] = value
         else:
             device[parentKey][key] = value
+        self.async_set_updated_data(self.data)
+
+    def update_endpoint_power(self, node_id: int, endpoint_id: int, power: str) -> None:
+        """Optimistically update power state for a specific electricalEndpoints entry."""
+        device = self.get_node(node_id)
+        endpoints = device.get("electricalEndpoints")
+        if isinstance(endpoints, list):
+            for ep in endpoints:
+                if not isinstance(ep, dict):
+                    continue
+                if ep.get("id") == endpoint_id:
+                    ep["lastReportedValue"] = power
+                    break
         self.async_set_updated_data(self.data)

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -1,0 +1,257 @@
+"""Fan setup for Enki integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.fan import (
+    DIRECTION_FORWARD,
+    DIRECTION_REVERSE,
+    FanEntity,
+    FanEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import EnkiConfigEntry
+from .base import EnkiBaseEntity
+from .coordinator import EnkiCoordinator
+
+
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: EnkiConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up fan entities."""
+    coordinator: EnkiCoordinator = config_entry.runtime_data.coordinator
+
+    fans = [
+        EnkiFan(coordinator, device, "state")
+        for device in coordinator.data
+        if _is_fan_device(device)
+    ]
+
+    async_add_entities(fans)
+
+
+class EnkiFan(EnkiBaseEntity, FanEntity):
+    """Representation of an Enki fan."""
+
+    _attr_supported_features = FanEntityFeature(0)
+    _attr_preset_modes: list[str] = []
+
+    def __init__(self, coordinator: EnkiCoordinator, device: dict[str, Any], parameter: str) -> None:
+        super().__init__(coordinator, device, parameter)
+        self.parameter = "fan"
+
+        self._capabilities = _capabilities_set(device)
+        self._possible_values = _possible_values_dict(device)
+        self._max_fan_speed = _fan_max_speed(device)
+        self._supports_speed = _supports_fan_speed(self._capabilities, self._possible_values) and self._max_fan_speed is not None
+        self._supports_direction = _supports_fan_direction(self._capabilities, self._possible_values)
+        self._attr_preset_modes = _airflow_modes(self._possible_values)
+        self._supports_preset_mode = _supports_airflow_mode(self._capabilities, self._possible_values) and bool(self._attr_preset_modes)
+        self._supports_power = "switch_electrical_power" in self._capabilities
+
+        self._attr_supported_features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self._supports_speed:
+            self._attr_supported_features |= FanEntityFeature.SET_SPEED
+        if self._supports_direction:
+            self._attr_supported_features |= FanEntityFeature.DIRECTION
+        if self._supports_preset_mode:
+            self._attr_supported_features |= FanEntityFeature.PRESET_MODE
+
+    @property
+    def percentage(self) -> int | None:
+        """Return fan speed percentage."""
+        if not self._supports_speed:
+            return None
+
+        speed = self.coordinator.get_device_parameter(self.node_id, "fanSpeed")
+        if speed is None:
+            return None
+        speed_value = max(0, min(self._max_fan_speed, int(speed)))
+        return round((speed_value / self._max_fan_speed) * 100)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return if fan is on."""
+        if not self._supports_speed:
+            last_reported = self.coordinator.get_device_parameter(self.node_id, "lastReportedValue")
+            if isinstance(last_reported, dict):
+                power = last_reported.get("power")
+                if isinstance(power, str):
+                    return power == "ON"
+            return None
+
+        speed = self.coordinator.get_device_parameter(self.node_id, "fanSpeed")
+        return speed is not None and int(speed) > 0
+
+    async def async_turn_on(
+        self, percentage: int | None = None, preset_mode: str | None = None, **kwargs: Any
+    ) -> None:
+        """Turn fan on."""
+        if preset_mode is not None and self._supports_preset_mode:
+            await self.async_set_preset_mode(preset_mode)
+
+        if not self._supports_speed:
+            if self._supports_power:
+                await self.coordinator.api.switch_electrical_power(self.device["homeId"], self.node_id, "ON")
+            return
+
+        target_percentage = percentage if percentage is not None else 15
+        await self.async_set_percentage(target_percentage)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn fan off by setting speed to 0."""
+        if not self._supports_speed:
+            if self._supports_power:
+                await self.coordinator.api.switch_electrical_power(self.device["homeId"], self.node_id, "OFF")
+            return
+
+        await self.coordinator.api.change_fan_speed(self.device["homeId"], self.node_id, 0)
+        self.coordinator.update_data(self.node_id, None, "fanSpeed", 0)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set speed percentage."""
+        if not self._supports_speed:
+            return
+
+        bounded = max(0, min(100, percentage))
+        speed = round((bounded / 100) * self._max_fan_speed)
+        await self.coordinator.api.change_fan_speed(self.device["homeId"], self.node_id, speed)
+        self.coordinator.update_data(self.node_id, None, "fanSpeed", speed)
+
+    @property
+    def current_direction(self) -> str | None:
+        """Return current fan direction."""
+        if not self._supports_direction:
+            return None
+
+        value = self.coordinator.get_device_parameter(self.node_id, "fanRotationDirection")
+        if value == "COUNTERCLOCKWISE":
+            return DIRECTION_REVERSE
+        if value == "CLOCKWISE":
+            return DIRECTION_FORWARD
+        return None
+
+    async def async_set_direction(self, direction: str) -> None:
+        """Set fan direction."""
+        if not self._supports_direction:
+            return
+
+        value = "CLOCKWISE" if direction == DIRECTION_FORWARD else "COUNTERCLOCKWISE"
+        await self.coordinator.api.change_fan_rotation_direction(
+            self.device["homeId"], self.node_id, value
+        )
+        self.coordinator.update_data(self.node_id, None, "fanRotationDirection", value)
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return airflow mode as preset mode."""
+        if not self._supports_preset_mode:
+            return None
+
+        value = self.coordinator.get_device_parameter(self.node_id, "airflowMode")
+        if value in self._attr_preset_modes:
+            return value
+        return None
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set airflow mode."""
+        if not self._supports_preset_mode:
+            return
+
+        if preset_mode not in self._attr_preset_modes:
+            raise ValueError(f"Unsupported preset mode: {preset_mode}")
+
+        await self.coordinator.api.change_airflow_mode(
+            self.device["homeId"], self.node_id, preset_mode
+        )
+        self.coordinator.update_data(self.node_id, None, "airflowMode", preset_mode)
+
+
+def _capabilities_set(device: dict[str, Any]) -> set[str]:
+    """Return capabilities as a normalized string set."""
+    capabilities = device.get("capabilities")
+    if isinstance(capabilities, list):
+        return {capability for capability in capabilities if isinstance(capability, str)}
+    if isinstance(capabilities, dict):
+        return set(capabilities.keys())
+    return set()
+
+
+def _possible_values_dict(device: dict[str, Any]) -> dict[str, Any]:
+    """Return possibleValues metadata as a dict if available."""
+    possible_values = device.get("possibleValues")
+    if isinstance(possible_values, dict):
+        return possible_values
+    return {}
+
+
+def _supports_fan_speed(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    """Tell whether fan speed control exists in metadata."""
+    return (
+        "change_fan_speed" in capabilities
+        or "check_fan_speed" in capabilities
+        or "change_fan_speed" in possible_values
+        or "check_fan_speed" in possible_values
+    )
+
+
+def _supports_fan_direction(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    """Tell whether fan direction control exists in metadata."""
+    return (
+        "change_fan_rotation_direction" in capabilities
+        or "check_fan_rotation_direction" in capabilities
+        or "change_fan_rotation_direction" in possible_values
+        or "check_fan_rotation_direction" in possible_values
+    )
+
+
+def _supports_airflow_mode(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    """Tell whether airflow mode exists in metadata."""
+    return (
+        "change_airflow_mode" in capabilities
+        or "check_airflow_mode" in capabilities
+        or "change_airflow_mode" in possible_values
+        or "check_airflow_mode" in possible_values
+    )
+
+
+def _fan_max_speed(device: dict[str, Any]) -> int | None:
+    """Read max fan speed from possibleValues. Returns None if not available."""
+    possible_values = _possible_values_dict(device)
+    speed_meta = possible_values.get("change_fan_speed") or possible_values.get("check_fan_speed")
+    if isinstance(speed_meta, dict):
+        speed_range = speed_meta.get("range")
+        if isinstance(speed_range, dict):
+            raw_max = speed_range.get("max")
+            if isinstance(raw_max, (int, float)) and raw_max > 0:
+                return max(1, int(round(raw_max)))
+    return None
+
+
+def _airflow_modes(possible_values: dict[str, Any]) -> list[str]:
+    """Read airflow mode options from possibleValues metadata. Returns [] if not available."""
+    airflow_meta = possible_values.get("change_airflow_mode") or possible_values.get("check_airflow_mode")
+    if isinstance(airflow_meta, dict):
+        values = airflow_meta.get("values")
+        if isinstance(values, list):
+            return [value for value in values if isinstance(value, str)]
+    return []
+
+
+def _is_fan_device(device: dict[str, Any]) -> bool:
+    """Detect fan devices from capabilities/possibleValues metadata."""
+    capabilities = _capabilities_set(device)
+    possible_values = _possible_values_dict(device)
+
+    return (
+        _supports_fan_speed(capabilities, possible_values)
+        or _supports_fan_direction(capabilities, possible_values)
+        or _supports_airflow_mode(capabilities, possible_values)
+    )

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -19,25 +19,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ):
     """Set up the Binary Sensors."""
-    # This gets the data update coordinator from the config entry runtime data as specified in your __init__.py
     coordinator: EnkiCoordinator = config_entry.runtime_data.coordinator
 
-    # ----------------------------------------------------------------------------
-    # Here we are going to add some lights entities for the lights in our mock data.
-    # We have an on/off light and a dimmable light in our mock data, so add each
-    # specific class based on the light type.
-    # ----------------------------------------------------------------------------
-    lights = []
-
-    lights.extend(
-        [
-            EnkiLight(coordinator, device, "state")
-            for device in coordinator.data
-            if device.get("type") == "lights"
-        ]
-    )
-
-    # Create the lights.
+    lights = [
+        entity
+        for device in coordinator.data
+        for entity in _build_light_entities(coordinator, device)
+    ]
     async_add_entities(lights)
 
 class EnkiLight(EnkiBaseEntity, LightEntity):
@@ -49,41 +37,51 @@ class EnkiLight(EnkiBaseEntity, LightEntity):
     BRIGHTNESS_SCALE = (1,255)
 
     def __init__(
-        self, coordinator: EnkiCoordinator, device: dict[str, Any], parameter: str
+        self,
+        coordinator: EnkiCoordinator,
+        device: dict[str, Any],
+        parameter: str,
+        endpoint_id: int | None = None,
     ) -> None:
         """Initialise entity."""
         super().__init__(coordinator, device, parameter)
         self._device = device
-        if "possibleValues" in device and "change_brightness" in device["possibleValues"]:
-            min = device["possibleValues"]["change_brightness"]["range"]["min"]
-            max = device["possibleValues"]["change_brightness"]["range"]["max"]
-            LOGGER.debug("brightness min : " + str(min))
-            LOGGER.debug("brightness max : " + str(max))
-            self.BRIGHTNESS_SCALE = (min, max)
+        self._endpoint_id = endpoint_id
+        self._color_temp_values = []
+        self.parameter = parameter
+        self._attr_supported_color_modes = set()  # instance-level to avoid class mutation
+        self._attr_color_mode = None
 
-        if "change_color_temperature" in device["capabilities"]:
+        capabilities = _capabilities_set(device)
+        if "possibleValues" in device and "change_brightness" in device["possibleValues"]:
+            min_value = device["possibleValues"]["change_brightness"]["range"]["min"]
+            max_value = device["possibleValues"]["change_brightness"]["range"]["max"]
+            LOGGER.debug("brightness min : " + str(min_value))
+            LOGGER.debug("brightness max : " + str(max_value))
+            self.BRIGHTNESS_SCALE = (min_value, max_value)
+
+        if "change_color_temperature" in capabilities:
             self._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
             self._attr_color_mode = ColorMode.COLOR_TEMP
             if "possibleValues" in device and "change_color_temperature" in device["possibleValues"]:
                 values = device["possibleValues"]["change_color_temperature"]["values"]
-                min = int(values[0][1:-1])
-                max = int(values[-1][1:-1])
-                self._attr_min_color_temp_kelvin=min
-                self._attr_max_color_temp_kelvin=max
-                self._color_temp_values = []
+                min_value = int(values[0][1:-1])
+                max_value = int(values[-1][1:-1])
+                self._attr_min_color_temp_kelvin=min_value
+                self._attr_max_color_temp_kelvin=max_value
                 for val in values:
                     self._color_temp_values.append(int(val[1:-1]))
             else:
                 self._attr_min_color_temp_kelvin=DEFAULT_MIN_KELVIN
                 self._attr_max_color_temp_kelvin=DEFAULT_MAX_KELVIN
 
-        if "change_brightness" in device["capabilities"]:
+        if "change_brightness" in capabilities:
             if len(self._attr_supported_color_modes) == 0:
                 self._attr_supported_color_modes.add(ColorMode.BRIGHTNESS)
             if self._attr_color_mode is None:
                 self._attr_color_mode = ColorMode.BRIGHTNESS
 
-        if "switch_electrical_power" in  device["capabilities"]:
+        if "switch_electrical_power" in capabilities:
             if len(self._attr_supported_color_modes) == 0:
                 self._attr_supported_color_modes.add(ColorMode.ONOFF)
                 self._attr_color_mode = ColorMode.ONOFF
@@ -94,17 +92,45 @@ class EnkiLight(EnkiBaseEntity, LightEntity):
     @property
     def is_on(self) -> bool | None:
         """Return if the binary sensor is on."""
-        # This needs to enumerate to true or false
+        if self._endpoint_id is not None:
+            endpoints = self.coordinator.get_device_parameter(self.node_id, "electricalEndpoints")
+            if isinstance(endpoints, list):
+                for ep in endpoints:
+                    if not isinstance(ep, dict):
+                        continue
+                    if ep.get("id") == self._endpoint_id:
+                        endpoint_lrv = ep.get("lastReportedValue")
+                        if isinstance(endpoint_lrv, str):
+                            return endpoint_lrv == "ON"
+                        if isinstance(endpoint_lrv, dict):
+                            power = endpoint_lrv.get("power")
+                            return power == "ON" if power is not None else None
+
+        # Fallback for devices without per-endpoint status shape.
         last_reported_values = self.coordinator.get_device_parameter(self.node_id, "lastReportedValue")
-        return (
-            last_reported_values["power"] == "ON"
-        )
+        if isinstance(last_reported_values, dict):
+            power = last_reported_values.get("power")
+            return power == "ON" if power is not None else None
+        return None
 
     def closest_temp_value(self, target_value):
         return min(self._color_temp_values, key=lambda x: abs(x - target_value)) 
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
+        # TODO: switch_electrical_power([endpoint_id]) turns on ALL endpoints of the device (lights, fan, etc).
+        # Until the API supports per-endpoint control without side-effects, use change_light_state
+        # for all light entities regardless of whether they have an endpoint_id. This will turn on
+        # all the lights but at least will not turn on the fan or other non-light endpoints.
+        # if self._endpoint_id is not None:
+        #     await self.coordinator.api.switch_electrical_power(
+        #         self._device["homeId"],
+        #         self._device["nodeId"],
+        #         "ON",
+        #         [self._endpoint_id],
+        #     )
+        #     return
+
         if "brightness" in kwargs:
             ha_value = kwargs["brightness"]
             value = round(ha_value / (255/self.BRIGHTNESS_SCALE[1]), 2)
@@ -119,21 +145,97 @@ class EnkiLight(EnkiBaseEntity, LightEntity):
             self.coordinator.update_data(self.node_id, "lastReportedValue", "colorTemperature", "T" + str(value) + "K")
         else:
             await self.coordinator.api.change_light_state(self._device["homeId"], self._device["nodeId"], "power", "ON")
-            self.coordinator.update_data(self.node_id, "lastReportedValue", "power", "ON")
+            if self._endpoint_id is not None:
+                self.coordinator.update_endpoint_power(self.node_id, self._endpoint_id, "ON")
+            else:
+                self.coordinator.update_data(self.node_id, "lastReportedValue", "power", "ON")
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
+        # TODO: switch_electrical_power([endpoint_id]) turns off ALL endpoints of the device (lights, fan, etc).
+        # Until the API supports per-endpoint control without side-effects, use change_light_state
+        # for all light entities regardless of whether they have an endpoint_id. This will turn off
+        # all the lights but at least will not turn off the fan or other non-light endpoints.
+        # if self._endpoint_id is not None:
+        #     await self.coordinator.api.switch_electrical_power(
+        #         self._device["homeId"],
+        #         self._device["nodeId"],
+        #         "OFF",
+        #         [self._endpoint_id],
+        #     )
+        #     return
+
         await self.coordinator.api.change_light_state(self._device["homeId"], self._device["nodeId"], "power", "OFF")
-        self.coordinator.update_data(self.node_id, "lastReportedValue", "power", "OFF")
+        if self._endpoint_id is not None:
+            self.coordinator.update_endpoint_power(self.node_id, self._endpoint_id, "OFF")
+        else:
+            self.coordinator.update_data(self.node_id, "lastReportedValue", "power", "OFF")
 
     @property
     def brightness(self) -> Optional[int]:
         """Return the current brightness."""
         last_reported_values = self.coordinator.get_device_parameter(self.node_id, "lastReportedValue")
+        if "brightness" not in last_reported_values:
+            return None
         return last_reported_values["brightness"]*(255/self.BRIGHTNESS_SCALE[1])
     
     @property
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature in Kelvin."""
         last_reported_values = self.coordinator.get_device_parameter(self.node_id, "lastReportedValue")
+        if "colorTemperature" not in last_reported_values:
+            return None
         return int(last_reported_values["colorTemperature"][1:-1])
+
+
+def _build_light_entities(coordinator: EnkiCoordinator, device: dict[str, Any]) -> list[LightEntity]:
+    """Create light entities from power capability and BFF endpoint metadata."""
+    if not _has_switch_electrical_power(device):
+
+        return []
+
+    endpoint_ids = _main_change_capability_endpoint_ids(device)
+    if endpoint_ids:
+        return [
+            EnkiLight(coordinator, device, parameter=f"light_{chr(ord('a') + i)}", endpoint_id=endpoint_id)
+            for i, endpoint_id in enumerate(endpoint_ids)
+        ]
+
+    return [EnkiLight(coordinator, device, parameter="light", endpoint_id=None)]
+
+
+def _has_switch_electrical_power(device: dict[str, Any]) -> bool:
+    """Check whether the device supports switch_electrical_power capability."""
+    return "switch_electrical_power" in _capabilities_set(device)
+
+
+def _main_change_capability_endpoint_ids(device: dict[str, Any]) -> list[int]:
+    """Return BFF endpoints for mainChangeCapability=switch_electrical_power."""
+    if device.get("mainChangeCapabilityId") != "switch_electrical_power":
+        return []
+
+    raw_endpoints = device.get("mainChangeCapabilityEndpoints")
+    if not isinstance(raw_endpoints, list):
+        return []
+
+    endpoint_ids: set[int] = set()
+    for endpoint in raw_endpoints:
+        if isinstance(endpoint, int):
+            endpoint_ids.add(endpoint)
+            continue
+        if isinstance(endpoint, dict):
+            endpoint_id = endpoint.get("id")
+            if isinstance(endpoint_id, int):
+                endpoint_ids.add(endpoint_id)
+
+    return sorted(endpoint_ids)
+
+
+def _capabilities_set(device: dict[str, Any]) -> set[str]:
+    """Return a safe capability set from device metadata."""
+    capabilities = device.get("capabilities")
+    if isinstance(capabilities, list):
+        return {capability for capability in capabilities if isinstance(capability, str)}
+    if isinstance(capabilities, dict):
+        return set(capabilities.keys())
+    return set()

--- a/tools/enki_api_live.py
+++ b/tools/enki_api_live.py
@@ -1,0 +1,220 @@
+"""Standalone live diagnostics for Enki API (no pytest required)."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+
+def _load_enki_api_class():
+    """Load API class without importing Home Assistant integration package."""
+    component_dir = Path(__file__).resolve().parents[1] / "custom_components" / "enki"
+    package_name = "_enki_tools_runtime"
+
+    if package_name not in sys.modules:
+        package = types.ModuleType(package_name)
+        package.__path__ = [str(component_dir)]
+        sys.modules[package_name] = package
+
+    const_module_name = f"{package_name}.const"
+    if const_module_name not in sys.modules:
+        const_spec = importlib.util.spec_from_file_location(
+            const_module_name,
+            component_dir / "const.py",
+        )
+        if const_spec is None or const_spec.loader is None:
+            raise RuntimeError("Could not load const.py for live API script")
+        const_module = importlib.util.module_from_spec(const_spec)
+        sys.modules[const_module_name] = const_module
+        const_spec.loader.exec_module(const_module)
+
+    api_module_name = f"{package_name}.api"
+    api_spec = importlib.util.spec_from_file_location(
+        api_module_name,
+        component_dir / "api.py",
+    )
+    if api_spec is None or api_spec.loader is None:
+        raise RuntimeError("Could not load api.py for live API script")
+
+    api_module = importlib.util.module_from_spec(api_spec)
+    sys.modules[api_module_name] = api_module
+    api_spec.loader.exec_module(api_module)
+
+    return api_module.API
+
+
+async def _run_live_api_check(user: str, password: str) -> None:
+    api_cls = _load_enki_api_class()
+    api = api_cls(user, password)
+
+    connected = await api.connect()
+    if connected is not True:
+        raise RuntimeError("Enki API login did not return True")
+
+    devices = await api.get_devices()
+    if not isinstance(devices, list):
+        raise RuntimeError("Enki API did not return a device list")
+
+    print(f"\nDevices found: {len(devices)}")
+    for index, device in enumerate(devices, start=1):
+        name = device.get("deviceName") or "unknown-device"
+        device_type = device.get("type") or "unknown-type"
+        device_kind = device.get("deviceType") or "unknown-deviceType"
+        node_id = device.get("nodeId") or "unknown-node"
+
+        print(
+            f"{index}. {name} | type={device_type} | deviceType={device_kind} | node={node_id}"
+        )
+        print("   raw-json:")
+        print(json.dumps(device, indent=2, ensure_ascii=False, sort_keys=True))
+
+        if device_kind == "ceiling_fans":
+            home_id = device.get("homeId")
+            await _print_ceiling_fan_endpoint_details(api, home_id, node_id, device.get("deviceId"))
+        elif _is_normal_light_device(device):
+            home_id = device.get("homeId")
+            await _print_normal_light_details(api, home_id, node_id)
+
+
+def _is_normal_light_device(device: dict[str, Any]) -> bool:
+    """Detect non-ceiling-fan lights that should print check-light-state details."""
+    if device.get("deviceType") == "ceiling_fans":
+        return False
+
+    if device.get("type") == "lights":
+        return True
+
+    capabilities = device.get("capabilities")
+    return isinstance(capabilities, list) and (
+        "check_light_state" in capabilities or "change_light_state" in capabilities
+    )
+
+
+async def _print_normal_light_details(api: Any, home_id: str, node_id: str) -> None:
+    """Print check-light-state for regular lights without endpoint semantics."""
+    print("\n   --- check-light-state (normal light) ---")
+    details = await api.get_light_details(home_id, node_id)
+    if not details:
+        print("   No light-state details returned")
+        return
+
+    print(json.dumps(details, indent=2, ensure_ascii=False, sort_keys=True))
+
+
+async def _print_ceiling_fan_endpoint_details(api: Any, home_id: str, node_id: str, device_id: str) -> None:
+    """Print all available endpoint info for a ceiling_fans device."""
+    import aiohttp
+
+    # Reuse the already-loaded const module to avoid homeassistant import
+    const = sys.modules["_enki_tools_runtime.const"]
+    enki_url = const.ENKI_URL
+    enki_referentiel_api_key = const.ENKI_REFERENTIEL_API_KEY
+    enki_bff_api_key = const.ENKI_BFF_API_KEY
+
+    auth_headers = {
+        "Authorization": f"{api._token_type} {api._access_token}",
+    }
+
+    async with aiohttp.ClientSession() as session:
+        # 1. referentiel-agg: device model capabilities (no per-endpoint type labels)
+        print("\n   --- referentiel-agg device (model capabilities) ---")
+        async with session.get(
+            f"{enki_url}/api-enki-referentiel-agg-prod/v1/devices/{device_id}",
+            headers={**auth_headers, "X-Gateway-APIKey": enki_referentiel_api_key},
+        ) as resp:
+            if resp.status == 200:
+                body = await resp.json()
+                print(
+                    f"   type={body.get('type')} "
+                    f"| i18n={body.get('i18n')} "
+                    f"| manufacturer={body.get('manufacturerId')}"
+                )
+                print(f"   protocols: {body.get('protocols')}")
+                print(f"   capabilities: {body.get('capabilities')}")
+                print(f"   possibleValues: {body.get('possibleValues')}")
+            else:
+                print(f"   HTTP {resp.status}: {await resp.text()}")
+
+        # 2. BFF dashboard node: which endpoints are exposed via mainChangeCapability
+        print("\n   --- BFF mainChangeCapability endpoints ---")
+        async with session.get(
+            f"{enki_url}/api-enki-mobile-bff-prod/v1/dashboard/homes/{home_id}?hasGroups=true",
+            headers={**auth_headers, "X-Gateway-APIKey": enki_bff_api_key},
+        ) as resp:
+            if resp.status == 200:
+                body = await resp.json()
+
+                def find_node(data: Any, target: str) -> Any:
+                    if isinstance(data, dict):
+                        if data.get("nodeId") == target or data.get("id") == target:
+                            return data
+                        for value in data.values():
+                            found = find_node(value, target)
+                            if found:
+                                return found
+                    elif isinstance(data, list):
+                        for item in data:
+                            found = find_node(item, target)
+                            if found:
+                                return found
+                    return None
+
+                node = find_node(body, node_id)
+                if node:
+                    cap = node.get("mainChangeCapability", {})
+                    eps = cap.get("endpoints", [])
+                    print(f"   mainChangeCapabilityId={node.get('mainChangeCapabilityId')}")
+                    print(f"   endpoints exposed by BFF: {[ep['id'] for ep in eps]}")
+                else:
+                    print(f"   Node {node_id} not found in BFF dashboard")
+            else:
+                print(f"   HTTP {resp.status}: {await resp.text()}")
+
+
+def _run_async(coro: Any) -> None:
+    """Run async code with a Windows-compatible event loop policy."""
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(coro)
+        # Let pending transport callbacks flush before closing the loop.
+        loop.run_until_complete(asyncio.sleep(0))
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+def main() -> int:
+    """Entry point for standalone live diagnostics script."""
+    parser = argparse.ArgumentParser(
+        description="Run Enki live API diagnostics (equivalent to tests/test_api_live.py, without pytest)."
+    )
+    parser.add_argument("--user", default=os.getenv("ENKI_USER"), help="Enki username/email")
+    parser.add_argument("--password", default=os.getenv("ENKI_PASSWORD"), help="Enki password")
+    args = parser.parse_args()
+
+    if not args.user or not args.password:
+        print("Missing credentials. Set ENKI_USER and ENKI_PASSWORD or pass --user/--password.")
+        return 2
+
+    try:
+        _run_async(_run_live_api_check(args.user, args.password))
+    except Exception as exc:  # pragma: no cover - defensive path for runtime diagnostics script
+        print(f"Error running live diagnostics: {exc}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
I've a ceiling fan with double light called Inspire Radix, so I tried to add suppor for it.

**I'm not a Python developer, so I used Github Copilot to make this changes. If you don't like them, please feel free to close this PR or take only what you want for it. I will not be able to do a "big fix" over the PR because Python is not my language.**

The change is big, it changes how light devices are detected. I changed to to do it using "capabilities" to not need to add devices with lights each time (lights, ceiling fans, strip lights, etc.). So maybe I've break the standalone light because I don't have one to test it. Please test it with your light to see if it works before merging anything.

My fan has two lights. The device has three endpoints, 1 and 3 are lights and 2 is the fan. With the Enki app I can turn on or off any of the lights individually, but I have not been able to do the same with this integration. Both lights are on or off at the same time. I've added a comment in the code as a TODO, maybe other person can fix it in a future.

Other changes include:
- Fix errors and warnings that appear in Home Assistant
- Add configurable polling interval during setup/reconfigure flows. Each 5 seconds is too much and maybe they ban us, so moved to 60 by default configurable when the integration is added in Home Assistant. Feel free to change it again if you want.
- Add standalone live API diagnostics script and document usage in README. This uses the API to ask for all devices and capabilities and prints it.

Regards and thanks for opening the path to the integration in Home Assistant.