### PR TITLE
Fix : Correct get access when `None`

### DIFF
--- a/custom_components/enki/api.py
+++ b/custom_components/enki/api.py
@@ -141,7 +141,7 @@ class API:
                                     endpoint.get("id")
                                     for endpoint in item["metadata"].get("mainChangeCapability", {}).get("endpoints", [])
                                     if endpoint.get("id") is not None
-                                ],
+                                ] if item["metadata"].get("mainChangeCapability") is not None else [],
                                 "deviceName": item["title"]["label"],
                                 "state": item["state"],
                                 "isEnabled": item["isEnabled"]


### PR DESCRIPTION
Fix error when dict key was `None`.

Cf example : 

```python
print({ "a": None }.get('a', {}))
```
`> None`