### PR TITLE
fix(light): support outlets without light-state capability (e.g. Edisio Wi-Fi plug ED-PLUGPI16-E1)

### DIFF
--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -53,6 +53,16 @@ class EnkiLight(EnkiBaseEntity, LightEntity):
         self._attr_color_mode = None
 
         capabilities = _capabilities_set(device)
+
+        # Some devices (e.g. Edisio Wi-Fi plugs/outlets) only expose
+        # switch_electrical_power / check_electrical_power and do not support
+        # change_light_state / check_light_state at all. For those devices we
+        # must use the power API (switch_electrical_power) instead of the
+        # lighting API (change_light_state) to change or read their state.
+        self._supports_light_state = bool(
+            {"change_light_state", "check_light_state"} & capabilities
+        )
+
         if "possibleValues" in device and "change_brightness" in device["possibleValues"]:
             min_value = device["possibleValues"]["change_brightness"]["range"]["min"]
             max_value = device["possibleValues"]["change_brightness"]["range"]["max"]
@@ -110,7 +120,16 @@ class EnkiLight(EnkiBaseEntity, LightEntity):
         last_reported_values = self.coordinator.get_device_parameter(self.node_id, "lastReportedValue")
         if isinstance(last_reported_values, dict):
             power = last_reported_values.get("power")
-            return power == "ON" if power is not None else None
+            if power is not None:
+                return power == "ON"
+
+        # Fallback for pure switch/outlet devices (e.g. Edisio Wi-Fi plugs)
+        # that report their state via switch_electrical_power /
+        # check_electrical_power instead of change_light_state.
+        electrical_power = self.coordinator.get_device_parameter(self.node_id, "electricalPower")
+        if isinstance(electrical_power, str) and electrical_power in ("ON", "OFF"):
+            return electrical_power == "ON"
+
         return None
 
     def closest_temp_value(self, target_value):
@@ -187,6 +206,16 @@ class EnkiLight(EnkiBaseEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
+        if not self._supports_light_state:
+            # Pure switch/outlet devices (e.g. Edisio Wi-Fi plugs) do not
+            # support change_light_state/check_light_state. Use the power
+            # API (switch_electrical_power) instead of the lighting API.
+            await self.coordinator.api.switch_electrical_power(
+                self._device["homeId"], self._device["nodeId"], "ON"
+            )
+            self.coordinator.update_data(self.node_id, None, "electricalPower", "ON")
+            return
+
         # TODO: switch_electrical_power turns on ALL endpoints of the device (lights, fan, etc).
         # Until the API supports per-endpoint control without side-effects, use change_light_state
         # for all light entities regardless of whether they have an endpoint_id. This will turn on
@@ -210,6 +239,14 @@ class EnkiLight(EnkiBaseEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
+        if not self._supports_light_state:
+            # See async_turn_on: pure switch/outlet devices use the power API.
+            await self.coordinator.api.switch_electrical_power(
+                self._device["homeId"], self._device["nodeId"], "OFF"
+            )
+            self.coordinator.update_data(self.node_id, None, "electricalPower", "OFF")
+            return
+
         # TODO: switch_electrical_power turns off ALL endpoints of the device (lights, fan, etc).
         # Until the API supports per-endpoint control without side-effects, use change_light_state
         # for all light entities regardless of whether they have an endpoint_id. This will turn off


### PR DESCRIPTION
## Problem

Devices whose only relevant capability is `switch_electrical_power` /
`check_electrical_power` (pure Wi-Fi outlets/plugs, e.g. Edisio
`ED-PLUGPI16-E1`) are correctly exposed as a `light` entity by
`_build_light_entities()`, but turning them on/off fails with
`ValueError: bad credentials`, and their state is always reported as
"unknown".

### Steps to reproduce
1. Pair an Edisio Wi-Fi plug (model `ED-PLUGPI16-E1`, deviceType
   `outlets`) in the Enki app.
2. Add the device in Home Assistant via this integration.
3. The entity appears, but toggling it raises `bad credentials`, and
   the entity state never reflects the real ON/OFF state of the plug.

### Diagnostic output (tools/enki_api_live.py)
```json
{
  "deviceName": "Chauffe eau",
  "deviceType": "outlets",
  "manufacturerId": "Edisio",
  "modelNumber": "ED-PLUGPI16-E1",
  "capabilities": [
    "...",
    "switch_electrical_power",
    "check_electrical_power",
    "..."
  ],
  "electricalPower": "OFF",
  "mainChangeCapabilityId": "switch_electrical_power"
}
```
Note the absence of `change_light_state` / `check_light_state` in
`capabilities`.

## Root cause

`EnkiLight.async_turn_on` / `async_turn_off` unconditionally call
`api.change_light_state(...)`, which hits the **lighting** API
(`api-enki-lighting-prod/.../check-light-state` and
`change-light-state`). This API is designed for light bulbs and does
not work for this kind of plug, resulting in the `bad credentials`
error surfaced by `api.py`.

Separately, `EnkiLight.is_on` only reads
`lastReportedValue["power"]`, which is only populated for devices that
support `change_light_state` (via `_refresh_lights_device`). For pure
outlet devices, the relevant state is instead exposed as
`device["electricalPower"]` ("ON"/"OFF"), populated via
`get_electrical_power_details` / `switch_electrical_power` capability
— but this field was never consulted.

The `api.switch_electrical_power()` method (calling the correct
`api-enki-power-prod/.../switch-electrical-power` endpoint) already
existed in `api.py` but was unused.

## Fix

In `custom_components/enki/light.py`:

- `EnkiLight.__init__` now computes
  `self._supports_light_state = bool({"change_light_state",
  "check_light_state"} & capabilities)`.
- `async_turn_on` / `async_turn_off`: when
  `self._supports_light_state` is `False`, call
  `api.switch_electrical_power(home_id, node_id, "ON" | "OFF")`
  instead of `change_light_state`, and optimistically update
  `device["electricalPower"]` via `coordinator.update_data(...)`.
- `is_on`: added a fallback that reads `device["electricalPower"]`
  ("ON"/"OFF") when `lastReportedValue` doesn't contain a `power` key.

Devices that do support `change_light_state` (actual light bulbs) are
unaffected — they keep going through the existing lighting-API code
path unchanged.

## Testing

- Verified with a real Edisio Wi-Fi plug (`ED-PLUGPI16-E1`, deviceType
  `outlets`, "Chauffe eau" in my setup):
  - Entity now correctly reflects ON/OFF state on load.
  - Toggling the entity in Home Assistant turns the physical plug
    on/off, no more `bad credentials` error.
- Added a small standalone test (mocking the coordinator/API, no
  Home Assistant installation required) replaying the exact device
  payload returned by `tools/enki_api_live.py` for this device:
  - confirms `_supports_light_state` is `False` for this device,
  - confirms `is_on` reflects `electricalPower`,
  - confirms `async_turn_on` / `async_turn_off` call
    `switch_electrical_power` and never `change_light_state`,
  - confirms a device with `change_light_state` in its capabilities
    still takes the existing light code path.

## Possible follow-up

Longer term, pure `outlets`-type devices (no light-related
capabilities at all) might be better represented as a `switch` entity
rather than a `light` with `ColorMode.ONOFF`. This PR keeps the
current entity model (light platform) to minimize the diff and avoid
breaking existing entity IDs / automations for users who already have
this device paired; happy to discuss a follow-up if maintainers prefer
a dedicated `switch` platform for these devices.