### PR TITLE
docs: redirect README to canonical enki-integration-hass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 # hass-enki-component
 
-Enki custom component for Home Assistant
+> **Development has moved.** Active maintenance continues at **[cyrilcolinet/enki-integration-hass](https://github.com/cyrilcolinet/enki-integration-hass)**.
+>
+> This repository is the original Enki integration for Home Assistant. If you still use it, switch to the canonical repo — same domain (`enki`), same folder (`custom_components/enki`). Update via HACS or copy files from a [release](https://github.com/cyrilcolinet/enki-integration-hass/releases), then restart Home Assistant. Do not uninstall the integration.
+>
+> Migration guide: [docs/MIGRATION.md](https://github.com/cyrilcolinet/enki-integration-hass/blob/main/docs/MIGRATION.md) (available after [PR #62](https://github.com/cyrilcolinet/enki-integration-hass/pull/62) is released).
+>
+> Discussion: [issue #78](https://github.com/CyrilP/hass-enki-component/issues/78)
 
-Tested devices:
+---
+
+## History
+
+First Enki custom component for Home Assistant — started by [@CyrilP](https://github.com/CyrilP) for an Eglo V-link lamp, then extended by contributors (Radix fan, Envertech solar, Cadix fan, …).
+
+**Originally tested devices:**
 - Eglo V-link tunable white
 - Inspire Radix ceiling fan with light
-- NEW! Solar Panels by Envertech-Lexman
+- Solar Panels by Envertech-Lexman
 - Inspire Cadix ceiling fan with light
-
-Howto :
-
-- install HACS
-- add this repo
-- add Enki integration
 
 ## Live API test
 
@@ -39,3 +45,5 @@ export ENKI_USER="your-email@example.com"
 export ENKI_PASSWORD="your-password"
 python tools/enki_api_live.py
 ```
+
+The maintained fork keeps an equivalent tool under `tools/enki_api_live.py`.

--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -8,9 +8,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .const import DOMAIN
 from .coordinator import EnkiCoordinator
 
 #PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
@@ -25,6 +27,29 @@ class RuntimeData:
 
 
 EnkiConfigEntry = ConfigEntry[RuntimeData]
+
+CANONICAL_REPO_URL = "https://github.com/cyrilcolinet/enki-integration-hass"
+MIGRATION_GUIDE_URL = (
+    "https://github.com/cyrilcolinet/enki-integration-hass/blob/main/docs/MIGRATION.md"
+)
+DEPRECATED_ISSUE_ID = "integration_moved"
+
+
+def _create_deprecated_issue(hass: HomeAssistant) -> None:
+    """Surface deprecation in Settings → Repairs and on the integration card."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        DEPRECATED_ISSUE_ID,
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=DEPRECATED_ISSUE_ID,
+        translation_placeholders={
+            "repo_url": CANONICAL_REPO_URL,
+            "migration_url": MIGRATION_GUIDE_URL,
+        },
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: EnkiConfigEntry) -> bool:
@@ -59,6 +84,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: EnkiConfigEntry) 
     # Setup platforms (based on the list of entity types in PLATFORMS defined above)
     # This calls the async_setup method in each of your entity type files.
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    _create_deprecated_issue(hass)
 
     # Return true to denote a successful setup.
     return True

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
 
   ],
-  "version": "v0.1"
+  "version": "v0.7"
 }

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "integration_moved": {
+      "title": "This Enki integration is deprecated",
+      "description": "Development continues at {repo_url}. Update via HACS to the canonical repo (same domain `enki`) — do not uninstall the integration. Migration guide: {migration_url}"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- README banner pointing users to [cyrilcolinet/enki-integration-hass](https://github.com/cyrilcolinet/enki-integration-hass)
- **Settings → Repairs** warning on startup (`integration_moved`) — visible on the Enki integration card too
- Keeps original history + live API test section below
- Links to [#78](https://github.com/CyrilP/hass-enki-component/issues/78) for context
- Manifest bump `v0.7` for a last release before archive (optional)

No functional changes to device control — notification only.

## Companion work (my repo)
- Draft migration PR: https://github.com/cyrilcolinet/enki-integration-hass/pull/62
- User guide: https://github.com/cyrilcolinet/enki-integration-hass/blob/feat/legacy-config-migration/docs/MIGRATION.md

I'll wait for your OK on #78 before merging anything on my side.